### PR TITLE
Apply Main Dep Patches Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "adm-zip": "0.4.7",
+        "adm-zip": "0.4.11",
         "body-parser": "1.9.0",
         "busboy": "~0.3.0",
         "cfenv": "^1.0.4",
@@ -26,7 +26,6 @@
         "hbs": "^4.0.4",
         "humanize-ms": "1.0.1",
         "jquery": "^2.2.4",
-        "lodash": "4.17.4",
         "marked": "0.3.5",
         "method-override": "latest",
         "moment": "2.15.1",
@@ -37,7 +36,7 @@
         "mysql": "^2.18.1",
         "npmconf": "0.0.24",
         "optional": "^0.1.3",
-        "st": "0.2.4",
+        "st": "0.2.5",
         "stream-buffers": "^3.0.1",
         "tap": "^11.1.3",
         "typeorm": "^0.2.24",
@@ -207,9 +206,10 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha512-QHVQ6ekddFaGr9r2hBUC4gPw2wLqMZioXojt9BydQPbSh8us7+Q5xcUCUq+hnh4zAdauV3wqoY0quApjKqrhbA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.3.0"
       }
@@ -2907,12 +2907,6 @@
       "dependencies": {
         "lie": "3.1.1"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==",
-      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
@@ -7733,10 +7727,9 @@
       }
     },
     "node_modules/st": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/st/-/st-0.2.4.tgz",
-      "integrity": "sha512-3xF3j+99oVmpj3ESZKsztF7uZBHgvqGJla/BJbCea/wp1TGKJrcil/ZDN3D8JkRzIEcX1SyGF1d/D2Ce8/OKtg==",
-      "deprecated": "Please upgrade to at least 0.2.5 for a security fix",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/st/-/st-0.2.5.tgz",
+      "integrity": "sha512-gDuruHdRio7Qb5XK5OKON5EnTNFoEeuR4QBrTzWaobCQYS4gtZZrWDzsccHjYeSfngRGXBBEAvPTvUpgJMQnWw==",
       "license": "BSD",
       "dependencies": {
         "async-cache": "~0.1.2",
@@ -8869,9 +8862,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha512-QHVQ6ekddFaGr9r2hBUC4gPw2wLqMZioXojt9BydQPbSh8us7+Q5xcUCUq+hnh4zAdauV3wqoY0quApjKqrhbA=="
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -11011,11 +11004,6 @@
       "requires": {
         "lie": "3.1.1"
       }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -14520,9 +14508,9 @@
       }
     },
     "st": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/st/-/st-0.2.4.tgz",
-      "integrity": "sha512-3xF3j+99oVmpj3ESZKsztF7uZBHgvqGJla/BJbCea/wp1TGKJrcil/ZDN3D8JkRzIEcX1SyGF1d/D2Ce8/OKtg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/st/-/st-0.2.5.tgz",
+      "integrity": "sha512-gDuruHdRio7Qb5XK5OKON5EnTNFoEeuR4QBrTzWaobCQYS4gtZZrWDzsccHjYeSfngRGXBBEAvPTvUpgJMQnWw==",
       "requires": {
         "async-cache": "~0.1.2",
         "fd": "~0.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "test": "snyk test"
   },
   "dependencies": {
-    "adm-zip": "0.4.7",
+    "adm-zip": "0.4.11",
     "body-parser": "1.9.0",
+    "busboy": "~0.3.0",
     "cfenv": "^1.0.4",
     "consolidate": "0.14.5",
     "dustjs-helpers": "1.5.0",
@@ -31,7 +32,6 @@
     "hbs": "^4.0.4",
     "humanize-ms": "1.0.1",
     "jquery": "^2.2.4",
-    "lodash": "4.17.4",
     "marked": "0.3.5",
     "method-override": "latest",
     "moment": "2.15.1",
@@ -42,12 +42,11 @@
     "mysql": "^2.18.1",
     "npmconf": "0.0.24",
     "optional": "^0.1.3",
-    "st": "0.2.4",
+    "st": "0.2.5",
     "stream-buffers": "^3.0.1",
     "tap": "^11.1.3",
     "typeorm": "^0.2.24",
-    "validator": "^13.5.2",
-    "busboy": "~0.3.0"
+    "validator": "^13.5.2"
   },
   "devDependencies": {
     "browserify": "^13.1.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,9 +16,6 @@ var fileType = require('file-type');
 var AdmZip = require('adm-zip');
 var fs = require('fs');
 
-// prototype-pollution
-var _ = require('lodash');
-
 exports.index = function (req, res, next) {
   Todo.
     find({}).
@@ -344,11 +341,10 @@ exports.chat = {
       icon: '👋',
     };
 
-    _.merge(message, req.body.message, {
-      id: lastId++,
-      timestamp: Date.now(),
-      userName: user.name,
-    });
+    message = {message, ...req.body.message};
+    message.id = lastId++;
+    message.timestamp = Date.now();
+    message.userName = user.name;
 
     messages.push(message);
     res.send({ ok: true });


### PR DESCRIPTION
Apply any recommended patch updates on dependencies defined in the package.json. Also removed lodash cause its only used for 1 feature that can be easily written in vanilla JS